### PR TITLE
Add Raylib-Python-CFFI

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [PyOgre](http://www.ogre3d.org/tikiwiki/PyOgre) - Python bindings for the Ogre 3D render engine, can be used for games, simulations, anything 3D.
 * [PyOpenGL](http://pyopengl.sourceforge.net/) - Python ctypes bindings for OpenGL and it's related APIs.
 * [PySDL2](https://pysdl2.readthedocs.io) - A ctypes based wrapper for the SDL2 library.
+* [Raylib-Python-CFFI](https://electronstudio.github.io/raylib-python-cffi/) - Python Bindings for Raylib 4.0 - a library to enjoy videogames programming.
 * [RenPy](https://www.renpy.org/) - A Visual Novel engine.
 
 ## Geolocation


### PR DESCRIPTION
## What is this Python project?

Raylib and this subsequent project is a simple but effective way to learn games programming or continue your own projects with less distractions. Genuinely surprised to not see any Raylib bindings here yet but this one has impressed me the most.

## What's the difference between this Python project and similar ones?

This project supports Raylib 4.0 and several different versions including the C API and a more pythonistic API

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
